### PR TITLE
Add a custom TGW route table for the VENOM VPC connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ deployment.
 |------|---------|
 | terraform | ~> 0.12.0 |
 | aws | ~> 3.0 |
+| null | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
 | aws | ~> 3.0 |
+| aws.organizationsreadonly | ~> 3.0 |
 | aws.sharedservicesprovisionaccount | ~> 3.0 |
+| null | ~> 3.0 |
 | terraform | n/a |
 
 ## Inputs ##
@@ -53,6 +56,8 @@ deployment.
 | Name | Description |
 |------|-------------|
 | venom_customer_gateway | The gateway for the site-to-site VPN connection to VENOM. |
+| venom_tgw_route_table | The custom Transit Gateway route table for the VENOM VPN connection. |
+| venom_tgw_route_table_association | The association between the VENOM VPN connection and its custom Transit Gateway route table. |
 | venom_vpn_connection | The site-to-site VPN connection to VENOM. |
 
 ## Notes ##

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,16 @@ output "venom_customer_gateway" {
   description = "The gateway for the site-to-site VPN connection to VENOM."
 }
 
+output "venom_tgw_route_table" {
+  value       = aws_ec2_transit_gateway_route_table.venom
+  description = "The custom Transit Gateway route table for the VENOM VPN connection."
+}
+
+output "venom_tgw_route_table_association" {
+  value       = aws_ec2_transit_gateway_route_table_association.venom
+  description = "The association between the VENOM VPN connection and its custom Transit Gateway route table."
+}
+
 output "venom_vpn_connection" {
   value       = aws_vpn_connection.venom
   description = "The site-to-site VPN connection to VENOM."

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Associate to the TGW VPN attachment a non-default route table that
+# Associate the TGW VPN attachment to a non-default route table that
 # allows communication to the Shared Services account but nowhere
 # else.  This serves to isolate the VENOM VPN tunnel from other
 # accounts.

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -8,6 +8,12 @@
 resource "aws_ec2_transit_gateway_route_table" "venom" {
   provider = aws.sharedservicesprovisionaccount
 
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "VENOM s2s VPN route table"
+    },
+  )
   transit_gateway_id = data.terraform_remote_state.networking.outputs.transit_gateway.id
 }
 

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -1,0 +1,60 @@
+# ------------------------------------------------------------------------------
+# Associate to the TGW VPN attachment a non-default route table that
+# allows communication to the Shared Services account but nowhere
+# else.  This serves to isolate the VENOM VPN tunnel from other
+# accounts.
+# ------------------------------------------------------------------------------
+
+resource "aws_ec2_transit_gateway_route_table" "venom" {
+  provider = aws.sharedservicesprovisionaccount
+
+  transit_gateway_id = data.terraform_remote_state.networking.outputs.transit_gateway.id
+}
+
+# Add a route to Shared Services to the route table
+resource "aws_ec2_transit_gateway_route" "venom_sharedservices" {
+  provider = aws.sharedservicesprovisionaccount
+
+  destination_cidr_block         = data.terraform_remote_state.networking.outputs.vpc.cidr_block
+  transit_gateway_attachment_id  = data.terraform_remote_state.networking.outputs.transit_gateway_sharedservices_vpc_attachment.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.venom.id
+}
+
+# Break the association between the transit gateway attachment and the
+# default transit gateway route table.
+#
+# It would be nice not to have to use the Terraform escape hatch for
+# this, but if I don't do this first then I get "error associating EC2
+# Transit Gateway Route Table (tgw-rtb-<id>) association
+# (tgw-attach-<id>): Resource.AlreadyAssociated: Transit Gateway
+# Attachment tgw-attach-<id> is already associated to a route table."
+resource "null_resource" "break_association_with_default_route_table" {
+  # Require that the transit gateway attachment is created before
+  # breaking the association.
+  depends_on = [
+    aws_vpn_connection.venom,
+  ]
+
+  provisioner "local-exec" {
+    when = create
+    # This command asks AWS to disassociate the default route table
+    # from our transit gateway attachment, then loops until the
+    # disassociation is complete.
+    command = "aws --profile cool-sharedservices-provisionaccount --region ${var.aws_region} ec2 disassociate-transit-gateway-route-table --transit-gateway-route-table-id ${data.terraform_remote_state.networking.outputs.transit_gateway.association_default_route_table_id} --transit-gateway-attachment-id ${aws_vpn_connection.venom.transit_gateway_attachment_id} && while aws --profile cool-sharedservices-provisionaccount --region ${var.aws_region} ec2 get-transit-gateway-route-table-associations --transit-gateway-route-table-id ${data.terraform_remote_state.networking.outputs.transit_gateway.association_default_route_table_id} | grep --quiet ${aws_vpn_connection.venom.id}; do sleep 5s; done"
+  }
+
+  triggers = {
+    tgw_default_route_table_id = data.terraform_remote_state.networking.outputs.transit_gateway.association_default_route_table_id
+    tgw_vpc_attachment_id      = aws_vpn_connection.venom.transit_gateway_attachment_id
+  }
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "venom" {
+  depends_on = [
+    null_resource.break_association_with_default_route_table,
+  ]
+  provider = aws.sharedservicesprovisionaccount
+
+  transit_gateway_attachment_id  = aws_vpn_connection.venom.transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.venom.id
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,7 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 3.0"
+    aws  = "~> 3.0"
+    null = "~> 3.0"
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a custom Transit Gateway route table for the VENOM VPC connection.

## 💭 Motivation and context ##

This restricts access from the VENOM tunnel to only the SharedServices account.

## 🧪 Testing ##

All `pre-commit` hooks pass.  These changes have already been applied to our staging COOL environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
