### PR TITLE
Add a VENOM-specific security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ deployment.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws_region | The AWS region where the Shared Services account resides (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| provisionaccount_role_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `ProvisionAccount` | no |
+| provisionvenom_policy_description | The description to associate with the IAM policy that allows provisioning of the VENOM layer in the Shared Services account. | `string` | `Allows provisioning of the VENOM layer in the Shared Services account.` | no |
+| provisionvenom_policy_name | The name to assign the IAM policy that allows provisioning of the VENOM layer in the Shared Services account. | `string` | `ProvisionVenom` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
+| venom_cidrs | A map with keys equal to the VENOM CIDR blocks and values equal to a brief description (e.g. {"10.200.0.0/16": "Primary", "10.201.0.0/16": "Secondary"}). | `map(string)` | n/a | yes |
 | venom_tunnel_ip | The IP address of the site-to-site VPN tunnel endpoint on the VENOM side (e.g. "100.200.75.25") | `string` | n/a | yes |
 | venom_vpn_preshared_key | The pre-shared key to use for setting up the site-to-site VPN connection between the COOL and VENOM.  This must be a string of 36 characters, which can include alphanumerics, periods, and underscores (e.g. "abcdefghijklmnopqrstuvwxyz01234567._"). | `string` | n/a | yes |
 
@@ -56,6 +60,8 @@ deployment.
 | Name | Description |
 |------|-------------|
 | venom_customer_gateway | The gateway for the site-to-site VPN connection to VENOM. |
+| venom_prefix_list | A prefix list for the VENOM CIDRs. |
+| venom_security_group | A security group that allows for all necessary communications between the VENOM agents and the VENOM CIDRs. |
 | venom_tgw_route_table | The custom Transit Gateway route table for the VENOM VPN connection. |
 | venom_tgw_route_table_association | The association between the VENOM VPN connection and its custom Transit Gateway route table. |
 | venom_vpn_connection | The site-to-site VPN connection to VENOM. |

--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 [![GitHub Build Status](https://github.com/cisagov/cool-sharedservices-venom/workflows/build/badge.svg)](https://github.com/cisagov/cool-sharedservices-venom/actions)
 
 This is a Terraform deployment for creating the site-to-site VPN
-tunnel between the COOL and the VENOM (Virtual Enterprise
-Network Operations Manager) environment in the COOL Shared
-Services account.  This deployment should be laid down on top of
-[cisagov/cool-sharedservices-networking](https://github.com/cisagov/cool-sharedservices-networking).
+tunnel between the COOL and the VENOM (Virtual Enterprise Network
+Operations Manager) environment in the COOL Shared Services account.
+This deployment should be applied immediately after
+[cisagov/cool-sharedservices-networking](https://github.com/cisagov/cool-sharedservices-networking),
+and before
+[cisagov/cool-sharedservices-freeipa](https://github.com/cisagov/cool-sharedservices-freeipa)
+or
+[cisagov/cool-sharedservices-openvpn](https://github.com/cisagov/cool-sharedservices-openvpn).
 
 ## Pre-requisites ##
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ Network Operations Manager) environment in the COOL Shared
 Services account.  This deployment should be laid down on top of
 [cisagov/cool-sharedservices-networking](https://github.com/cisagov/cool-sharedservices-networking).
 
-Note that this deployment does not need to attach an additional policy
-to the provisioning role; all necessary permissions have already been
-added by the policy attached in the
-[cisagov/cool-sharedservices-networking](https://github.com/cisagov/cool-sharedservices-networking)
-deployment.
-
 ## Pre-requisites ##
 
 - [Terraform](https://www.terraform.io/) installed on your system.

--- a/locals.tf
+++ b/locals.tf
@@ -47,4 +47,43 @@ locals {
   # example, "Shared Services (Production)".
   sharedservices_account_type = length(regexall("\\(([^()]*)\\)", local.sharedservices_account_name)) == 1 ? regex("\\(([^()]*)\\)", local.sharedservices_account_name)[0] : "Unknown"
   workspace_type              = lower(local.sharedservices_account_type)
+
+  #
+  # Helpful lists for defining ACL and security group rules
+  #
+
+  # The ports the VENOM agents use to communicate with the VENOM
+  # environment.
+  venom_ports = {
+    tanium_ingress = {
+      egress = false
+      port   = 17472,
+      proto  = "tcp",
+    },
+    tanium_egress = {
+      egress = true
+      port   = 17472,
+      proto  = "tcp",
+    },
+    tanium_threat_response_ingress = {
+      egress = false
+      port   = 17475,
+      proto  = "tcp",
+    },
+    tanium_threat_response_egress = {
+      egress = true
+      port   = 17475,
+      proto  = "tcp",
+    },
+    tenable_ingress = {
+      egress = false
+      port   = 8834,
+      proto  = "tcp",
+    },
+    tenable_egress = {
+      egress = true
+      port   = 8834,
+      proto  = "tcp",
+    },
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,16 @@ output "venom_customer_gateway" {
   description = "The gateway for the site-to-site VPN connection to VENOM."
 }
 
+output "venom_prefix_list" {
+  value       = aws_ec2_managed_prefix_list.venom
+  description = "A prefix list for the VENOM CIDRs."
+}
+
+output "venom_security_group" {
+  value       = aws_security_group.venom
+  description = "A security group that allows for all necessary communications between the VENOM agents and the VENOM CIDRs."
+}
+
 output "venom_tgw_route_table" {
   value       = aws_ec2_transit_gateway_route_table.venom
   description = "The custom Transit Gateway route table for the VENOM VPN connection."

--- a/prefix_list.tf
+++ b/prefix_list.tf
@@ -1,0 +1,24 @@
+# Prefix list for the VENOM CIDRs
+resource "aws_ec2_managed_prefix_list" "venom" {
+  provider = aws.sharedservicesprovisionaccount
+
+  address_family = "IPv4"
+  max_entries    = 2
+  name           = "VENOM CIDRs"
+
+  dynamic "entry" {
+    for_each = var.venom_cidrs
+
+    content {
+      cidr        = entry.key
+      description = entry.value
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "VENOM CIDRs"
+    },
+  )
+}

--- a/provisionvenom_policy.tf
+++ b/provisionvenom_policy.tf
@@ -1,0 +1,35 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows all of the additional permissions
+# necessary to provision the VENOM layer in the Shared Services
+# account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "provisionvenom_policy_doc" {
+  statement {
+    actions = [
+      "ec2:AuthorizeSecurityGroupEgress",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CreateManagedPrefixList",
+      "ec2:CreateSecurityGroup",
+      "ec2:DeleteManagedPrefixList",
+      "ec2:DeleteSecurityGroup",
+      "ec2:ModifyManagedPrefixList",
+      "ec2:RevokeSecurityGroupEgress",
+      "ec2:RevokeSecurityGroupIngress",
+      "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+      "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "provisionvenom_policy" {
+  provider = aws.sharedservicesprovisionaccount
+
+  description = var.provisionvenom_policy_description
+  name        = var.provisionvenom_policy_name
+  policy      = data.aws_iam_policy_document.provisionvenom_policy_doc.json
+}

--- a/provisionvenom_policy_attachment.tf
+++ b/provisionvenom_policy_attachment.tf
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------------
+# Attach to the ProvisionAccount role the IAM policy that allows
+# provisioning of the VENOM layer in the Shared Services account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "provisionvenom_policy_attachment" {
+  provider = aws.sharedservicesprovisionaccount
+
+  policy_arn = aws_iam_policy.provisionvenom_policy.arn
+  role       = var.provisionaccount_role_name
+}

--- a/s2s_vpn_tunnel.tf
+++ b/s2s_vpn_tunnel.tf
@@ -24,8 +24,8 @@ resource "aws_vpn_connection" "venom" {
   # It doesn't really matter, since I will define what traffic flows
   # into the customer gateway via TGW routing tables.
   #
-  # local_ipv4_network_cidr = "10.240.208.0/21"
-  # remote_ipv4_network_cidr = aws_vpc.the_vpc.cidr_block
+  # local_ipv4_network_cidr = var.venom_cidrs["East"]
+  # remote_ipv4_network_cidr = data.terraform_remote_state.networking.outputs.vpc.cidr_block
   static_routes_only = true
   tags = merge(
     var.tags,

--- a/s2s_vpn_tunnel.tf
+++ b/s2s_vpn_tunnel.tf
@@ -26,6 +26,10 @@ resource "aws_vpn_connection" "venom" {
   # This doesn't really matter (I hope), since I will define what
   # traffic flows into the customer gateway via TGW routing tables.
   #
+  # We should be able to make use of these parameters once this pull
+  # request is approved and merged:
+  # https://github.com/hashicorp/terraform-provider-aws/pull/17573
+  #
   # local_ipv4_network_cidr = var.venom_cidrs["East"]
   # remote_ipv4_network_cidr = data.terraform_remote_state.networking.outputs.vpc.cidr_block
   static_routes_only = true

--- a/s2s_vpn_tunnel.tf
+++ b/s2s_vpn_tunnel.tf
@@ -20,9 +20,11 @@ resource "aws_vpn_connection" "venom" {
   provider = aws.sharedservicesprovisionaccount
 
   customer_gateway_id = aws_customer_gateway.venom.id
-  # These two resources seem to want a /32, which I do not understand.
-  # It doesn't really matter, since I will define what traffic flows
-  # into the customer gateway via TGW routing tables.
+  # These two resources seem to want a /32, which is incorrect.  See this GitHub issue:
+  # https://github.com/hashicorp/terraform-provider-aws/issues/16879
+  #
+  # This doesn't really matter (I hope), since I will define what
+  # traffic flows into the customer gateway via TGW routing tables.
   #
   # local_ipv4_network_cidr = var.venom_cidrs["East"]
   # remote_ipv4_network_cidr = data.terraform_remote_state.networking.outputs.vpc.cidr_block

--- a/security_group.tf
+++ b/security_group.tf
@@ -14,14 +14,14 @@ resource "aws_security_group" "venom" {
   )
 }
 
-# Egress rules
-# resource "aws_security_group_rule" "client_egress" {
-#   for_each = local.ipa_ports
+resource "aws_security_group_rule" "venom" {
+  for_each = local.venom_ports
+  provider = aws.sharedservicesprovisionaccount
 
-#   security_group_id        = aws_security_group.client.id
-#   type                     = "egress"
-#   protocol                 = each.value.proto
-#   source_security_group_id = aws_security_group.server.id
-#   from_port                = each.value.port
-#   to_port                  = each.value.port
-# }
+  security_group_id = aws_security_group.venom.id
+  type              = each.value.egress ? "egress" : "ingress"
+  prefix_list_ids   = [aws_ec2_managed_prefix_list.venom.id]
+  protocol          = each.value.proto
+  from_port         = each.value.port
+  to_port           = each.value.port
+}

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,0 +1,27 @@
+# Security group for instances that run VENOM agents (Tainium and
+# Tenable)
+resource "aws_security_group" "venom" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = data.terraform_remote_state.networking.outputs.vpc.id
+
+  description = "VENOM"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "VENOM"
+    },
+  )
+}
+
+# Egress rules
+# resource "aws_security_group_rule" "client_egress" {
+#   for_each = local.ipa_ports
+
+#   security_group_id        = aws_security_group.client.id
+#   type                     = "egress"
+#   protocol                 = each.value.proto
+#   source_security_group_id = aws_security_group.server.id
+#   from_port                = each.value.port
+#   to_port                  = each.value.port
+# }

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,4 +1,4 @@
-# Security group for instances that run VENOM agents (Tainium and
+# Security group for instances that run VENOM agents (Tanium and
 # Tenable)
 resource "aws_security_group" "venom" {
   provider = aws.sharedservicesprovisionaccount

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "venom_cidrs" {
+  type        = map(string)
+  description = "A map with keys equal to the VENOM CIDR blocks and values equal to a brief description (e.g. {\"10.200.0.0/16\": \"Primary\", \"10.201.0.0/16\": \"Secondary\"})."
+}
+
 variable "venom_tunnel_ip" {
   type        = string
   description = "The IP address of the site-to-site VPN tunnel endpoint on the VENOM side (e.g. \"100.200.75.25\")"
@@ -24,6 +29,24 @@ variable "aws_region" {
   type        = string
   description = "The AWS region where the Shared Services account resides (e.g. \"us-east-1\")."
   default     = "us-east-1"
+}
+
+variable "provisionaccount_role_name" {
+  type        = string
+  description = "The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
+  default     = "ProvisionAccount"
+}
+
+variable "provisionvenom_policy_description" {
+  type        = string
+  description = "The description to associate with the IAM policy that allows provisioning of the VENOM layer in the Shared Services account."
+  default     = "Allows provisioning of the VENOM layer in the Shared Services account."
+}
+
+variable "provisionvenom_policy_name" {
+  type        = string
+  description = "The name to assign the IAM policy that allows provisioning of the VENOM layer in the Shared Services account."
+  default     = "ProvisionVenom"
 }
 
 variable "tags" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a VENOM-specific security group.

## 💭 Motivation and context ##

We need such a security group so we can apply it to instances that are using the VENOM agents (Tenable and Tanium).

## 🧪 Testing ##

All `pre-commit` hooks pass.  These changes have already been applied to our COOL staging environment.  I can't fully test until I create a pull request in [cisagov/cool-sharedservices-freeipa](https://github.com/cisagov/cool-sharedservices-freeipa) that uses the security group.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
