### PR TITLE
Add Route53 resolver endpoints and rules for VENOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ or
 
 | Name | Description |
 |------|-------------|
+| dns_from_venom_security_group | The security group that allows inbound DNS requests from the VENOM environment. |
+| dns_to_venom_security_group | The security group that allows outbound DNS requests to the VENOM environment. |
+| route53_resolver_endpoint_from_venom | The security group that allows inbound DNS requests from the VENOM environment. |
+| route53_resolver_endpoint_to_venom | The security group that allows outbound DNS requests to the VENOM environment. |
 | venom_customer_gateway | The gateway for the site-to-site VPN connection to VENOM. |
 | venom_prefix_list | A prefix list for the VENOM CIDRs. |
 | venom_security_group | A security group that allows for all necessary communications between the VENOM agents and the VENOM CIDRs. |

--- a/README.md
+++ b/README.md
@@ -50,17 +50,21 @@ or
 | provisionvenom_policy_name | The name to assign the IAM policy that allows provisioning of the VENOM layer in the Shared Services account. | `string` | `ProvisionVenom` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | venom_cidrs | A map with keys equal to the VENOM CIDR blocks and values equal to a brief description (e.g. {"10.200.0.0/16": "Primary", "10.201.0.0/16": "Secondary"}). | `map(string)` | n/a | yes |
-| venom_tunnel_ip | The IP address of the site-to-site VPN tunnel endpoint on the VENOM side (e.g. "100.200.75.25") | `string` | n/a | yes |
+| venom_dns_ips | The DNS server IPs for the VENOM environment (e.g. ["100.200.75.25", "100.200.100.50"]). | `list(string)` | n/a | yes |
+| venom_domains | The domains for the VENOM environment (e.g. ["venom.cisa.gov", "venom.cisa.dhs.gov"]). | `list(string)` | `["venom.cisa.gov", "venom.cisa.dhs.gov"]` | no |
+| venom_tunnel_ip | The IP address of the site-to-site VPN tunnel endpoint on the VENOM side (e.g. "100.200.75.25"). | `string` | n/a | yes |
 | venom_vpn_preshared_key | The pre-shared key to use for setting up the site-to-site VPN connection between the COOL and VENOM.  This must be a string of 36 characters, which can include alphanumerics, periods, and underscores (e.g. "abcdefghijklmnopqrstuvwxyz01234567._"). | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| dns_from_venom_security_group | The security group that allows inbound DNS requests from the VENOM environment. |
-| dns_to_venom_security_group | The security group that allows outbound DNS requests to the VENOM environment. |
-| route53_resolver_endpoint_from_venom | The security group that allows inbound DNS requests from the VENOM environment. |
-| route53_resolver_endpoint_to_venom | The security group that allows outbound DNS requests to the VENOM environment. |
+| dns_from_venom_security_group | The security group that allows DNS requests from the VENOM environment. |
+| dns_to_venom_security_group | The security group that allows DNS requests to the VENOM environment. |
+| route53_resolver_endpoint_from_venom | The Route53 resolver that allows the VENOM environment to resolve DNS queries in our environment. |
+| route53_resolver_endpoint_to_venom | The Route53 resolver that allows us to resolve DNS queries in the VENOM environment. |
+| route53_resolver_rules_to_venom | The Route53 resolver rules that allow us to resolve DNS queries in the VENOM environment. |
+| route53_resolver_rules_to_venom_ram_shares | The RAM shares for the Route53 resolver rules that allow us to resolve DNS queries in the VENOM environment. |
 | venom_customer_gateway | The gateway for the site-to-site VPN connection to VENOM. |
 | venom_prefix_list | A prefix list for the VENOM CIDRs. |
 | venom_security_group | A security group that allows for all necessary communications between the VENOM agents and the VENOM CIDRs. |

--- a/locals.tf
+++ b/locals.tf
@@ -86,4 +86,10 @@ locals {
       proto  = "tcp",
     },
   }
+
+  # Useful when creating some security group or ACL rules
+  tcp_and_udp = [
+    "tcp",
+    "udp",
+  ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,23 @@
+output "dns_from_venom_security_group" {
+  value       = aws_security_group.dns_from_venom
+  description = "The security group that allows inbound DNS requests from the VENOM environment."
+}
+
+output "dns_to_venom_security_group" {
+  value       = aws_security_group.dns_to_venom
+  description = "The security group that allows outbound DNS requests to the VENOM environment."
+}
+
+output "route53_resolver_endpoint_from_venom" {
+  value       = aws_route53_resolver_endpoint.from_venom
+  description = "The security group that allows inbound DNS requests from the VENOM environment."
+}
+
+output "route53_resolver_endpoint_to_venom" {
+  value       = aws_route53_resolver_endpoint.to_venom
+  description = "The security group that allows outbound DNS requests to the VENOM environment."
+}
+
 output "venom_customer_gateway" {
   value       = aws_customer_gateway.venom
   description = "The gateway for the site-to-site VPN connection to VENOM."

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,21 +1,31 @@
 output "dns_from_venom_security_group" {
   value       = aws_security_group.dns_from_venom
-  description = "The security group that allows inbound DNS requests from the VENOM environment."
+  description = "The security group that allows DNS requests from the VENOM environment."
 }
 
 output "dns_to_venom_security_group" {
   value       = aws_security_group.dns_to_venom
-  description = "The security group that allows outbound DNS requests to the VENOM environment."
+  description = "The security group that allows DNS requests to the VENOM environment."
 }
 
 output "route53_resolver_endpoint_from_venom" {
   value       = aws_route53_resolver_endpoint.from_venom
-  description = "The security group that allows inbound DNS requests from the VENOM environment."
+  description = "The Route53 resolver that allows the VENOM environment to resolve DNS queries in our environment."
 }
 
 output "route53_resolver_endpoint_to_venom" {
   value       = aws_route53_resolver_endpoint.to_venom
-  description = "The security group that allows outbound DNS requests to the VENOM environment."
+  description = "The Route53 resolver that allows us to resolve DNS queries in the VENOM environment."
+}
+
+output "route53_resolver_rules_to_venom" {
+  value       = aws_route53_resolver_rule.to_venom
+  description = "The Route53 resolver rules that allow us to resolve DNS queries in the VENOM environment."
+}
+
+output "route53_resolver_rules_to_venom_ram_shares" {
+  value       = aws_ram_resource_share.to_venom
+  description = "The RAM shares for the Route53 resolver rules that allow us to resolve DNS queries in the VENOM environment."
 }
 
 output "venom_customer_gateway" {

--- a/route53_resolver_from_venom.tf
+++ b/route53_resolver_from_venom.tf
@@ -1,0 +1,56 @@
+# ------------------------------------------------------------------------------
+# Create Route53 resolver that allows the VENOM environment to resolve
+# DNS entries in our environment
+# ------------------------------------------------------------------------------
+
+# Security group for Route53 resolver that allows inbound DNS queries
+# from the VENOM environment.
+resource "aws_security_group" "dns_from_venom" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = data.terraform_remote_state.networking.outputs.vpc.id
+
+  description = "VENOM DNS - From VENOM"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "VENOM DNS - From VENOM"
+    },
+  )
+}
+resource "aws_security_group_rule" "dns_from_venom" {
+  for_each = toset(local.tcp_and_udp)
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id = aws_security_group.dns_from_venom.id
+  type              = "ingress"
+  prefix_list_ids   = [aws_ec2_managed_prefix_list.venom.id]
+  protocol          = each.key
+  from_port         = 53
+  to_port           = 53
+}
+
+resource "aws_route53_resolver_endpoint" "from_venom" {
+  provider = aws.sharedservicesprovisionaccount
+
+  direction = "INBOUND"
+
+  dynamic "ip_address" {
+    for_each = data.terraform_remote_state.networking.outputs.private_subnets
+
+    content {
+      subnet_id = ip_address.value.id
+    }
+  }
+
+  name = "From VENOM"
+  security_group_ids = [
+    aws_security_group.dns_from_venom.id,
+  ]
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Route53 resolver - from VENOM"
+    },
+  )
+}

--- a/route53_resolver_rules_to_venom.tf
+++ b/route53_resolver_rules_to_venom.tf
@@ -1,0 +1,55 @@
+# ------------------------------------------------------------------------------
+# Create Route53 resolver rules that allow us to resolve DNS entries
+# in the VENOM environment
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_resolver_rule" "to_venom" {
+  provider = aws.sharedservicesprovisionaccount
+  for_each = toset(var.venom_domains)
+
+  domain_name          = each.key
+  name                 = "Resolve VENOM domain"
+  rule_type            = "FORWARD"
+  resolver_endpoint_id = aws_route53_resolver_endpoint.to_venom.id
+
+  dynamic "target_ip" {
+    for_each = toset(var.venom_dns_ips)
+
+    content {
+      ip = target_ip.key
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "VENOM DNS - To VENOM"
+    },
+  )
+}
+
+# Associate the rules with our VPC
+resource "aws_route53_resolver_rule_association" "to_venom" {
+  provider = aws.sharedservicesprovisionaccount
+  for_each = aws_route53_resolver_rule.to_venom
+
+  resolver_rule_id = each.value.id
+  vpc_id           = data.terraform_remote_state.networking.outputs.vpc.id
+}
+
+# Create resource shares for the rules.  These will be used by the
+# userservices account.
+resource "aws_ram_resource_share" "to_venom" {
+  provider = aws.sharedservicesprovisionaccount
+  for_each = aws_route53_resolver_rule.to_venom
+
+  allow_external_principals = false
+  name                      = each.value.name
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "VENOM DNS - To VENOM"
+    },
+  )
+}

--- a/route53_resolver_rules_to_venom.tf
+++ b/route53_resolver_rules_to_venom.tf
@@ -38,7 +38,7 @@ resource "aws_route53_resolver_rule_association" "to_venom" {
 }
 
 # Create resource shares for the rules.  These will be used by the
-# userservices account.
+# User Services account.
 resource "aws_ram_resource_share" "to_venom" {
   provider = aws.sharedservicesprovisionaccount
   for_each = aws_route53_resolver_rule.to_venom

--- a/route53_resolver_to_venom.tf
+++ b/route53_resolver_to_venom.tf
@@ -1,0 +1,56 @@
+# ------------------------------------------------------------------------------
+# Create Route53 resolver that allows us to resolve DNS entries in the
+# VENOM environment
+# ------------------------------------------------------------------------------
+
+# Security group for Route53 resolver that allows outbound DNS queries
+# to the VENOM environment.
+resource "aws_security_group" "dns_to_venom" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = data.terraform_remote_state.networking.outputs.vpc.id
+
+  description = "VENOM DNS - To VENOM"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "VENOM DNS - To VENOM"
+    },
+  )
+}
+resource "aws_security_group_rule" "dns_to_venom" {
+  for_each = toset(local.tcp_and_udp)
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id = aws_security_group.dns_to_venom.id
+  type              = "egress"
+  prefix_list_ids   = [aws_ec2_managed_prefix_list.venom.id]
+  protocol          = each.key
+  from_port         = 53
+  to_port           = 53
+}
+
+resource "aws_route53_resolver_endpoint" "to_venom" {
+  provider = aws.sharedservicesprovisionaccount
+
+  direction = "OUTBOUND"
+
+  dynamic "ip_address" {
+    for_each = data.terraform_remote_state.networking.outputs.private_subnets
+
+    content {
+      subnet_id = ip_address.value.id
+    }
+  }
+
+  name = "To VENOM"
+  security_group_ids = [
+    aws_security_group.dns_to_venom.id,
+  ]
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Route53 resolver - to VENOM"
+    },
+  )
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,9 +9,14 @@ variable "venom_cidrs" {
   description = "A map with keys equal to the VENOM CIDR blocks and values equal to a brief description (e.g. {\"10.200.0.0/16\": \"Primary\", \"10.201.0.0/16\": \"Secondary\"})."
 }
 
+variable "venom_dns_ips" {
+  type        = list(string)
+  description = "The DNS server IPs for the VENOM environment (e.g. [\"100.200.75.25\", \"100.200.100.50\"])."
+}
+
 variable "venom_tunnel_ip" {
   type        = string
-  description = "The IP address of the site-to-site VPN tunnel endpoint on the VENOM side (e.g. \"100.200.75.25\")"
+  description = "The IP address of the site-to-site VPN tunnel endpoint on the VENOM side (e.g. \"100.200.75.25\")."
 }
 
 variable "venom_vpn_preshared_key" {
@@ -53,4 +58,10 @@ variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created."
   default     = {}
+}
+
+variable "venom_domains" {
+  type        = list(string)
+  description = "The domains for the VENOM environment (e.g. [\"venom.cisa.gov\", \"venom.cisa.dhs.gov\"])."
+  default     = ["venom.cisa.gov", "venom.cisa.dhs.gov"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,11 @@ variable "venom_dns_ips" {
   description = "The DNS server IPs for the VENOM environment (e.g. [\"100.200.75.25\", \"100.200.100.50\"])."
 }
 
+variable "venom_domains" {
+  type        = list(string)
+  description = "The domains for the VENOM environment (e.g. [\"venom.cisa.gov\", \"venom.cisa.dhs.gov\", \"222.111.10.in-addr.arpa\"])."
+}
+
 variable "venom_tunnel_ip" {
   type        = string
   description = "The IP address of the site-to-site VPN tunnel endpoint on the VENOM side (e.g. \"100.200.75.25\")."
@@ -58,10 +63,4 @@ variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created."
   default     = {}
-}
-
-variable "venom_domains" {
-  type        = list(string)
-  description = "The domains for the VENOM environment (e.g. [\"venom.cisa.gov\", \"venom.cisa.dhs.gov\"])."
-  default     = ["venom.cisa.gov", "venom.cisa.dhs.gov"]
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds Route53 resolver endpoints and resolver rules to allow:
* Us to resolve DNS entries in the VENOM environment
* The VENOM environment to resolve DNS entries in our environment

## 💭 Motivation and context ##

This is required for the VENOM integration to function.  Resolves cisagov/cool-system#164.

## 🧪 Testing ##

All `pre-commit` hooks pass.  These changes have already been applied to our staging COOL environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
