### PR TITLE
Allow ICMP ping to and from the VENOM environment

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -55,6 +55,16 @@ locals {
   # The ports the VENOM agents use to communicate with the VENOM
   # environment.
   venom_ports = {
+    ping_ingress = {
+      egress = false
+      port   = 8
+      proto  = "icmp"
+    },
+    ping_egress = {
+      egress = true
+      port   = 8
+      proto  = "icmp"
+    },
     tanium_ingress = {
       egress = false
       port   = 17472,


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some security group rules to allow ICMP ping to and from the VENOM environment.

## 💭 Motivation and context ##

Adding this does no harm, and it will likely prove useful when we test our VPN tunnel to the VENOM environment.

## 🧪 Testing ##

All pre-commit hooks pass.  These changes have already been applied to our staging COOL environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
