### PR TITLE
Create new DHCP options for the Shared Services VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,31 +45,33 @@ or
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws_region | The AWS region where the Shared Services account resides (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| cdm_cidr | The CIDR block on the CDM end of the site-to-site VPN tunnel (e.g. "10.201.0.0/16"). | `string` | n/a | yes |
+| cdm_dns_ips | The DNS server IPs for the CDM environment (e.g. ["100.200.75.25", "100.200.100.50"]). | `list(string)` | n/a | yes |
+| cdm_domains | The domains for the CDM environment (e.g. ["thulsa.example.com", "doom.example.com", "222.111.10.in-addr.arpa"]).  The first domain listed should be the main CDM domain, as it will be used as an additional search domain for DNS lookups. | `list(string)` | n/a | yes |
+| cdm_tunnel_ip | The IP address of the site-to-site VPN tunnel endpoint on the CDM side (e.g. "100.200.75.25"). | `string` | n/a | yes |
+| cdm_vpn_preshared_key | The pre-shared key to use for setting up the site-to-site VPN connection between the COOL and CDM.  This must be a string of 36 characters, which can include alphanumerics, periods, and underscores (e.g. "abcdefghijklmnopqrstuvwxyz01234567._"). | `string` | n/a | yes |
 | provisionaccount_role_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `ProvisionAccount` | no |
 | provisioncdm_policy_description | The description to associate with the IAM policy that allows provisioning of the CDM layer in the Shared Services account. | `string` | `Allows provisioning of the CDM layer in the Shared Services account.` | no |
 | provisioncdm_policy_name | The name to assign the IAM policy that allows provisioning of the CDM layer in the Shared Services account. | `string` | `ProvisionCdm` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| cdm_cidr | The CIDR block on the CDM end of the site-to-site VPN tunnel (e.g. "10.201.0.0/16"). | `string` | n/a | yes |
-| cdm_dns_ips | The DNS server IPs for the CDM environment (e.g. ["100.200.75.25", "100.200.100.50"]). | `list(string)` | n/a | yes |
-| cdm_domains | The domains for the CDM environment (e.g. ["thulsa.example.com", "doom.example.com", "222.111.10.in-addr.arpa"]). | `list(string)` | n/a | yes |
-| cdm_tunnel_ip | The IP address of the site-to-site VPN tunnel endpoint on the CDM side (e.g. "100.200.75.25"). | `string` | n/a | yes |
-| cdm_vpn_preshared_key | The pre-shared key to use for setting up the site-to-site VPN connection between the COOL and CDM.  This must be a string of 36 characters, which can include alphanumerics, periods, and underscores (e.g. "abcdefghijklmnopqrstuvwxyz01234567._"). | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
+| cdm_customer_gateway | The gateway for the site-to-site VPN connection to CDM. |
+| cdm_security_group | A security group that allows for all necessary communications between the CDM agents and the CDM CIDRs. |
+| cdm_tgw_route_table | The custom Transit Gateway route table for the CDM VPN connection. |
+| cdm_tgw_route_table_association | The association between the CDM VPN connection and its custom Transit Gateway route table. |
+| cdm_vpc_dhcp_options | The Shared Services VPC DHCP options.  These are identical to the DHCP options created in cisagov/cool-sharedservices-networking, except that we add the main CDM domain (var.cdm_domains[0]) to the DNS search path. |
+| cdm_vpc_dhcp_options_association | The association between the Shared Services VPC and the CDM-enhanced DHCP options. |
+| cdm_vpn_connection | The site-to-site VPN connection to CDM. |
 | dns_from_cdm_security_group | The security group that allows DNS requests from the CDM environment. |
 | dns_to_cdm_security_group | The security group that allows DNS requests to the CDM environment. |
 | route53_resolver_endpoint_from_cdm | The Route53 resolver that allows the CDM environment to resolve DNS queries in our environment. |
 | route53_resolver_endpoint_to_cdm | The Route53 resolver that allows us to resolve DNS queries in the CDM environment. |
 | route53_resolver_rules_to_cdm | The Route53 resolver rules that allow us to resolve DNS queries in the CDM environment. |
 | route53_resolver_rules_to_cdm_ram_shares | The RAM shares for the Route53 resolver rules that allow us to resolve DNS queries in the CDM environment. |
-| cdm_customer_gateway | The gateway for the site-to-site VPN connection to CDM. |
-| cdm_security_group | A security group that allows for all necessary communications between the CDM agents and the CDM CIDRs. |
-| cdm_tgw_route_table | The custom Transit Gateway route table for the CDM VPN connection. |
-| cdm_tgw_route_table_association | The association between the CDM VPN connection and its custom Transit Gateway route table. |
-| cdm_vpn_connection | The site-to-site VPN connection to CDM. |
 
 ## Notes ##
 

--- a/dhcp_options.tf
+++ b/dhcp_options.tf
@@ -1,0 +1,31 @@
+# A new, CDM-enhanced set of DHCP options for instances that run in
+# the Shared Services VPC.
+#
+# For the Tenable CDM agent to function it has to be able to look up
+# the CDM Tenable server in DNS using only the first segment of its
+# hostname; therefore, we have to add the "main" CDM domain as an
+# additional search domain.
+resource "aws_vpc_dhcp_options" "cdm" {
+  provider = aws.sharedservicesprovisionaccount
+
+  # The first domain listed is the main domain
+  domain_name          = format("%s %s", data.terraform_remote_state.networking.outputs.vpc_dhcp_options.domain_name, var.cdm_domains[0])
+  domain_name_servers  = data.terraform_remote_state.networking.outputs.vpc_dhcp_options.domain_name_servers
+  netbios_name_servers = data.terraform_remote_state.networking.outputs.vpc_dhcp_options.netbios_name_servers
+  netbios_node_type    = data.terraform_remote_state.networking.outputs.vpc_dhcp_options.netbios_node_type
+  ntp_servers          = data.terraform_remote_state.networking.outputs.vpc_dhcp_options.ntp_servers
+  tags = merge(
+    var.tags,
+    {
+      Name = "CDM"
+    },
+  )
+}
+
+# Associate the DHCP options with the Shared Services VPC
+resource "aws_vpc_dhcp_options_association" "cdm" {
+  provider = aws.sharedservicesprovisionaccount
+
+  dhcp_options_id = aws_vpc_dhcp_options.cdm.id
+  vpc_id          = data.terraform_remote_state.networking.outputs.vpc.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,38 @@
+output "cdm_customer_gateway" {
+  value       = aws_customer_gateway.cdm
+  description = "The gateway for the site-to-site VPN connection to CDM."
+}
+
+output "cdm_security_group" {
+  value       = aws_security_group.cdm
+  description = "A security group that allows for all necessary communications between the CDM agents and the CDM CIDRs."
+}
+
+output "cdm_tgw_route_table" {
+  value       = aws_ec2_transit_gateway_route_table.cdm
+  description = "The custom Transit Gateway route table for the CDM VPN connection."
+}
+
+output "cdm_tgw_route_table_association" {
+  value       = aws_ec2_transit_gateway_route_table_association.cdm
+  description = "The association between the CDM VPN connection and its custom Transit Gateway route table."
+}
+
+output "cdm_vpc_dhcp_options" {
+  value       = aws_vpc_dhcp_options.cdm
+  description = "The Shared Services VPC DHCP options.  These are identical to the DHCP options created in cisagov/cool-sharedservices-networking, except that we add the main CDM domain (var.cdm_domains[0]) to the DNS search path."
+}
+
+output "cdm_vpc_dhcp_options_association" {
+  value       = aws_vpc_dhcp_options_association.cdm
+  description = "The association between the Shared Services VPC and the CDM-enhanced DHCP options."
+}
+
+output "cdm_vpn_connection" {
+  value       = aws_vpn_connection.cdm
+  description = "The site-to-site VPN connection to CDM."
+}
+
 output "dns_from_cdm_security_group" {
   value       = aws_security_group.dns_from_cdm
   description = "The security group that allows DNS requests from the CDM environment."
@@ -26,29 +61,4 @@ output "route53_resolver_rules_to_cdm" {
 output "route53_resolver_rules_to_cdm_ram_shares" {
   value       = aws_ram_resource_share.to_cdm
   description = "The RAM shares for the Route53 resolver rules that allow us to resolve DNS queries in the CDM environment."
-}
-
-output "cdm_customer_gateway" {
-  value       = aws_customer_gateway.cdm
-  description = "The gateway for the site-to-site VPN connection to CDM."
-}
-
-output "cdm_security_group" {
-  value       = aws_security_group.cdm
-  description = "A security group that allows for all necessary communications between the CDM agents and the CDM CIDRs."
-}
-
-output "cdm_tgw_route_table" {
-  value       = aws_ec2_transit_gateway_route_table.cdm
-  description = "The custom Transit Gateway route table for the CDM VPN connection."
-}
-
-output "cdm_tgw_route_table_association" {
-  value       = aws_ec2_transit_gateway_route_table_association.cdm
-  description = "The association between the CDM VPN connection and its custom Transit Gateway route table."
-}
-
-output "cdm_vpn_connection" {
-  value       = aws_vpn_connection.cdm
-  description = "The site-to-site VPN connection to CDM."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "cdm_dns_ips" {
 
 variable "cdm_domains" {
   type        = list(string)
-  description = "The domains for the CDM environment (e.g. [\"thulsa.example.com\", \"doom.example.com\", \"222.111.10.in-addr.arpa\"])."
+  description = "The domains for the CDM environment (e.g. [\"thulsa.example.com\", \"doom.example.com\", \"222.111.10.in-addr.arpa\"]).  The first domain listed should be the main CDM domain, as it will be used as an additional search domain for DNS lookups."
 }
 
 variable "cdm_tunnel_ip" {


### PR DESCRIPTION
## 🗣 Description ##

These new options are identical to those created in cisagov/cool-sharedservices-networking#43, except that we add the main
CDM domain as an additional search domain.

We also add the DHCP options and the DHCP options association resources to the outputs, and proper alphabetize the outputs.

## 💭 Motivation and context ##

The Nessus agents running in Shared Services must be able to look up the CDM Nessus server in DNS using only the first segment of its hostname.  (This is apparently a limitation of the Nessus agent.)  For example, if the Nessus server is `nessus.example.com`, then a DNS query for `nessus` must successfully return the IP for `nessus.example.com`.  It follows, then, that we must add the CDM domain to the list of DNS search domains in the Shared Services VPC.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I also deployed these changes to our staging COOL environment and verified that they function as expected.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
