### PR TITLE
Modify CDM site-to-site VPN configuration to restart the tunnel if we detect a dead peer

### DIFF
--- a/s2s_vpn_tunnel.tf
+++ b/s2s_vpn_tunnel.tf
@@ -39,8 +39,11 @@ resource "aws_vpn_connection" "cdm" {
       "Name" = "CDM site-to-site VPN connection"
     },
   )
-  transit_gateway_id                   = data.terraform_remote_state.networking.outputs.transit_gateway.id
-  tunnel_inside_ip_version             = "ipv4"
+  transit_gateway_id       = data.terraform_remote_state.networking.outputs.transit_gateway.id
+  tunnel_inside_ip_version = "ipv4"
+  # Try to reconnect when we detect that the other side of the tunnel
+  # is dead
+  tunnel1_dpd_timeout_action           = "restart"
   tunnel1_ike_versions                 = ["ikev2"]
   tunnel1_phase1_dh_group_numbers      = [14]
   tunnel1_phase1_encryption_algorithms = ["AES256"]
@@ -51,6 +54,9 @@ resource "aws_vpn_connection" "cdm" {
   tunnel1_phase2_integrity_algorithms  = ["SHA2-384"]
   tunnel1_phase2_lifetime_seconds      = 3600
   tunnel1_preshared_key                = var.cdm_vpn_preshared_key
+  # Try to reconnect when we detect that the other side of the tunnel
+  # is dead
+  tunnel2_dpd_timeout_action           = "restart"
   tunnel2_ike_versions                 = ["ikev2"]
   tunnel2_phase1_dh_group_numbers      = [14]
   tunnel2_phase1_encryption_algorithms = ["AES256"]


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the CDM site-to-site VPN configuration to restart the tunnel if we detect a dead peer at the other end.

## 💭 Motivation and context ##

The secondary tunnel sometimes dies on us because there is no traffic flowing in it.  (The secondary tunnel is only used in the event that the primary tunnel goes down or is undergoing maintenance.)  The dead peer detection should be keeping this from happening, but (1) AWS hides most of the VPN details from me and (2) I have very limited insight into what is happening on the CDM side.  This change should automatically restart the connection if we detect that the other side of the tunnel is dead, which should at least help.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I also deployed these changes to our staging environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
