### PR TITLE
Set the local and remote CIDRs for the aws_vpn_connection resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ or
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 3.43 |
+| aws | ~> 3.42 |
 | null | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.43 |
-| aws.organizationsreadonly | ~> 3.43 |
-| aws.sharedservicesprovisionaccount | ~> 3.43 |
+| aws | ~> 3.42 |
+| aws.organizationsreadonly | ~> 3.42 |
+| aws.sharedservicesprovisionaccount | ~> 3.42 |
 | null | ~> 3.0 |
 | terraform | n/a |
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ or
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 3.0 |
+| aws | ~> 3.43 |
 | null | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
-| aws.organizationsreadonly | ~> 3.0 |
-| aws.sharedservicesprovisionaccount | ~> 3.0 |
+| aws | ~> 3.43 |
+| aws.organizationsreadonly | ~> 3.43 |
+| aws.sharedservicesprovisionaccount | ~> 3.43 |
 | null | ~> 3.0 |
 | terraform | n/a |
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ or
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 3.42 |
+| aws | ~> 3.43 |
 | null | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.42 |
-| aws.organizationsreadonly | ~> 3.42 |
-| aws.sharedservicesprovisionaccount | ~> 3.42 |
+| aws | ~> 3.43 |
+| aws.organizationsreadonly | ~> 3.43 |
+| aws.sharedservicesprovisionaccount | ~> 3.43 |
 | null | ~> 3.0 |
 | terraform | n/a |
 

--- a/s2s_vpn_tunnel.tf
+++ b/s2s_vpn_tunnel.tf
@@ -19,20 +19,10 @@ resource "aws_customer_gateway" "cdm" {
 resource "aws_vpn_connection" "cdm" {
   provider = aws.sharedservicesprovisionaccount
 
-  customer_gateway_id = aws_customer_gateway.cdm.id
-  # These two resources seem to want a /32, which is incorrect.  See this GitHub issue:
-  # https://github.com/hashicorp/terraform-provider-aws/issues/16879
-  #
-  # This doesn't really matter (I hope), since I will define what
-  # traffic flows into the customer gateway via TGW routing tables.
-  #
-  # We should be able to make use of these parameters once this pull
-  # request is approved and merged:
-  # https://github.com/hashicorp/terraform-provider-aws/pull/17573
-  #
-  # local_ipv4_network_cidr = var.cdm_cidr
-  # remote_ipv4_network_cidr = data.terraform_remote_state.networking.outputs.vpc.cidr_block
-  static_routes_only = true
+  customer_gateway_id      = aws_customer_gateway.cdm.id
+  local_ipv4_network_cidr  = var.cdm_cidr
+  remote_ipv4_network_cidr = data.terraform_remote_state.networking.outputs.vpc.cidr_block
+  static_routes_only       = true
   tags = merge(
     var.tags,
     {

--- a/s2s_vpn_tunnel.tf
+++ b/s2s_vpn_tunnel.tf
@@ -19,9 +19,14 @@ resource "aws_customer_gateway" "cdm" {
 resource "aws_vpn_connection" "cdm" {
   provider = aws.sharedservicesprovisionaccount
 
-  customer_gateway_id      = aws_customer_gateway.cdm.id
-  local_ipv4_network_cidr  = var.cdm_cidr
-  remote_ipv4_network_cidr = data.terraform_remote_state.networking.outputs.vpc.cidr_block
+  customer_gateway_id     = aws_customer_gateway.cdm.id
+  local_ipv4_network_cidr = var.cdm_cidr
+  # The cidrsubnets() here is because we want to give CDM as small a
+  # subnet as possible, since they are assuming there are no
+  # duplicates across the CISA enterprise.  All the instances that
+  # interest them (the OpenVPN and FreeIPA instances) are in the
+  # bottom /4 of the SharedServices CIDR block.
+  remote_ipv4_network_cidr = cidrsubnets(data.terraform_remote_state.networking.outputs.vpc.cidr_block, 4)[0]
   static_routes_only       = true
   tags = merge(
     var.tags,

--- a/s2s_vpn_tunnel.tf
+++ b/s2s_vpn_tunnel.tf
@@ -21,7 +21,7 @@ resource "aws_vpn_connection" "cdm" {
 
   customer_gateway_id     = aws_customer_gateway.cdm.id
   local_ipv4_network_cidr = var.cdm_cidr
-  # The cidrsubnets() here is because we want to give CDM as small a
+  # The cidrsubnet() here is because we want to give CDM as small a
   # subnet as possible, since they are assuming there are no
   # duplicates across the CISA enterprise.  All the instances that
   # interest them (the OpenVPN and FreeIPA instances) are contained in

--- a/versions.tf
+++ b/versions.tf
@@ -10,7 +10,7 @@ terraform {
     # correctly allows the local_ipv4_network_cidr and
     # remote_ipv4_network_cidr keys of the aws_vpn_connection resource
     # to be non-/32 CIDRs.
-    aws  = "~> 3.42"
+    aws  = "~> 3.43"
     null = "~> 3.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,11 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws  = "~> 3.0"
+    # 3.43.0 is the first version of the Terraform AWS provider that
+    # correctly allows the local_ipv4_network_cidr and
+    # remote_ipv4_network_cidr keys of the aws_vpn_connection resource
+    # to be non-/32 CIDRs.
+    aws  = "~> 3.42"
     null = "~> 3.0"
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

Set the local and remote CIDRs for the `aws_vpn_connection` resource via the `local_ipv4_network_cidr` and `remote_ipv4_network_cidr` keys.

This pull request also changes `versions.tf` to require version 3.43.0 or greater of the AWS Terraform provider, since version 3.43.0 is the first version that fixes a bug where these CIDRs were incorrectly required to be `/32`s.

## 💭 Motivation and context ##

I had been working around the bug in Terraform AWS provider by applying _without_ specifying values for the `local_ipv4_network_cidr` and `remote_ipv4_network_cidr` keys, then going into the AWS console and manually setting them to the correct values.  With this fix such manual intervention is no longer necessary.

See hashicorp/terraform-provider-aws#16879 and hashicorp/terraform-provider-aws#17573 for more details about the bugfix in the Terraform AWS provider.

## 🧪 Testing ##

I applied these changes to our production COOL environment (where I had already done the manual intervention described in the previous section) and verified that the `terraform apply` did not want to make changes to any resources.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
