### PR TITLE
Add a security group rule for the CrowdStrike Falcon sensor

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -22,3 +22,16 @@ resource "aws_security_group_rule" "cdm" {
   from_port         = each.value.from_port
   to_port           = each.value.to_port
 }
+
+# Allow HTTPS out anywhere.  This is necessary for the CrowdStrike
+# Falcon sensor to phone home.
+resource "aws_security_group_rule" "crowdstrike_falcon" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id = aws_security_group.cdm.id
+  type              = "egress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a security group rule for the CrowdStrike Falcon sensor.

## 💭 Motivation and context ##

The CrowdStrike Falcon sensor requires HTTPS egress to the internet in order to phone home.

Note that this access was already being granted to the FreeIPA and OpenVPN instances to allow for AWS API calls and automated updates, but it is good to explicitly add it here as well.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.