### PR TITLE
Remove resources that support the Tanium CDM agent

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -55,30 +55,6 @@ locals {
   # The ports the CDM agents use to communicate with the CDM
   # environment.
   cdm_ports = {
-    tanium_ingress = {
-      egress    = false
-      from_port = 17472
-      proto     = "tcp"
-      to_port   = 17472
-    },
-    tanium_egress = {
-      egress    = true
-      from_port = 17472
-      proto     = "tcp"
-      to_port   = 17472
-    },
-    tanium_threat_response_ingress = {
-      egress    = false
-      from_port = 17475
-      proto     = "tcp"
-      to_port   = 17475
-    },
-    tanium_threat_response_egress = {
-      egress    = true
-      from_port = 17475
-      proto     = "tcp"
-      to_port   = 17475
-    },
     tenable_ingress = {
       egress    = false
       from_port = 8834

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,5 +1,5 @@
-# Security group for instances that run CDM agents (Tanium and
-# Tenable)
+# Security group for instances that run CDM agents (e.g., CrowdStrike
+# Falconview, Tenable, etc.)
 resource "aws_security_group" "cdm" {
   provider = aws.sharedservicesprovisionaccount
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes resources that support the Tanium CDM agent.

## 💭 Motivation and context ##

Partially resolves:
- cisagov/freeipa-server-packer#126
- cisagov/openvpn-packer#107

See also:
- cisagov/freeipa-server-packer#130
- cisagov/openvpn-packer#109

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Deploy these changes to our staging COOL environment.
- [x] Delete `/cdm/tanium_hostname` from SSM Parameter Store in COOL staging.
- [x] Deploy these changes to our production COOL environment.
- [x] Delete `/cdm/tanium_hostname` from SSM Parameter Store in COOL production.