### PR TITLE
Support new COOL environment structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or
 
 | Name | Version |
 |------|---------|
-| terraform | >= 1.1 |
+| terraform | ~> 1.1 |
 | aws | ~> 5.0 |
 | null | ~> 3.0 |
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.1 |
+| terraform | >= 1.1 |
 | aws | ~> 5.0 |
 | null | ~> 3.0 |
 
@@ -149,6 +149,7 @@ or
 | provisioncdm\_policy\_description | The description to associate with the IAM policy that allows provisioning of the CDM layer in the Shared Services account. | `string` | `"Allows provisioning of the CDM layer in the Shared Services account."` | no |
 | provisioncdm\_policy\_name | The name to assign the IAM policy that allows provisioning of the CDM layer in the Shared Services account. | `string` | `"ProvisionCdm"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
+| terraform\_state\_bucket | The name of the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/backend.tf
+++ b/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-sharedservices-cdm/terraform.tfstate"

--- a/locals.tf
+++ b/locals.tf
@@ -32,22 +32,6 @@ locals {
   # The ID of the Shared Services account
   sharedservices_account_id = data.aws_caller_identity.sharedservices.account_id
 
-  # Look up the name of the Shared Services account from the AWS
-  # organizations provider
-  sharedservices_account_name = [
-    for account in data.aws_organizations_organization.cool.accounts :
-    account.name
-    if account.id == local.sharedservices_account_id
-  ][0]
-
-  # Determine the Shared Services account type (staging or production)
-  # based on the Shared Services account name.
-  #
-  # The account name format is "Shared Services (ACCOUNT_TYPE)" - for
-  # example, "Shared Services (Production)".
-  sharedservices_account_type = length(regexall("\\(([^()]*)\\)", local.sharedservices_account_name)) == 1 ? regex("\\(([^()]*)\\)", local.sharedservices_account_name)[0] : "Unknown"
-  workspace_type              = lower(local.sharedservices_account_type)
-
   #
   # Helpful lists for defining ACL and security group rules
   #

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -8,52 +8,44 @@ data "terraform_remote_state" "master" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/master.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/master.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "networking" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-sharedservices-networking/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-sharedservices-networking/terraform.tfstate"
   }
 
-  workspace = local.workspace_type
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "sharedservices" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/shared_services.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/shared_services.tfstate"
   }
 
-  # Note that this workspace is different from the others.  Since we
-  # use data from this remote state to compute local.workspace_type,
-  # we cannot use that local variable here; doing so would result in a
-  # Terraform "cycle" error.
-  #
-  # Instead, we rely on the name of our current Terraform workspace,
-  # which must match the name of one of the workspaces in
-  # cool-sharedservices-cdm (e.g. staging, production).
   workspace = terraform.workspace
 }
 
@@ -61,14 +53,13 @@ data "terraform_remote_state" "users" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/users.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/users.tfstate"
   }
 
-  # There is only a single Users account
-  workspace = "production"
+  workspace = terraform.workspace
 }

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "cdm_vpn_preshared_key" {
   type        = string
 }
 
+variable "terraform_state_bucket" {
+  description = "The name of the S3 bucket where Terraform state is stored."
+  nullable    = false
+  type        = string
+}
+
 # ------------------------------------------------------------------------------
 # Optional parameters
 #

--- a/versions.tf
+++ b/versions.tf
@@ -20,5 +20,5 @@ terraform {
 
   # Version 1.1 of Terraform is the first version to support the
   # nullable key in variable definitions.
-  required_version = ">= 1.1"
+  required_version = "~> 1.1"
 }


### PR DESCRIPTION
## 🗣 Description ##

This PR makes updates in support of the switchover from our legacy account/environment scheme (where staging and production accounts exist within the same AWS organization) to our new scheme (where they do not).

Highlights include:
* Removal of hard-coded references to production and staging resources
* Use of [partial backend configurations](https://developer.hashicorp.com/terraform/language/backend#partial-configuration)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The goal of this PR is to get us closer to our modernized account scheme where there is no more co-mingling of staging and production accounts.  Doing that will result in cleaner code across all COOL-related repositories as well as improved separation of resources across all COOL environments. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this updated Terraform in production, which is our only current environment for this repo, and as expected, nothing notable changed (just some tags that were never applied in the past).

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.